### PR TITLE
CMParts: Hide Reset action if Battery LED is not multicolor

### DIFF
--- a/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
@@ -141,10 +141,14 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        menu.add(0, MENU_RESET, 0, R.string.reset)
-                .setIcon(R.drawable.ic_settings_backup_restore)
-                .setAlphabeticShortcut('r')
-                .setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS | MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        if (getResources().getBoolean(
+                com.android.internal.R.bool.config_multiColorBatteryLed)) {
+            menu.add(0, MENU_RESET, 0, R.string.reset)
+                    .setIcon(R.drawable.ic_settings_backup_restore)
+                    .setAlphabeticShortcut('r')
+                    .setShowAsActionFlags(
+                            MenuItem.SHOW_AS_ACTION_ALWAYS | MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        }
     }
 
     @Override


### PR DESCRIPTION
Change-Id: Icb3c7d640cb540d69efa7186c84a92e4e780968d